### PR TITLE
Incompatibility between elasticsearch and elasticsearch-py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,16 @@ from distutils.core import setup
 
 setup(
     name="panoply_elasticsearch",
-    version="1.0.4",
+    version="1.0.5",
     description="Panoply Data Source for Elasticsearch",
     author="Lior Rozen",
     author_email="lior@panoply.io",
     url="http://panoply.io",
     install_requires=[
         "panoply-python-sdk==1.3.2",
-        "elasticsearch==2.4.1",
+        "elasticsearch2",
+        "elasticsearch5",
+        "elasticsearch>=6.0.0,<7.0.0"
     ],
 
     # place this package within the panoply package namespace


### PR DESCRIPTION
[TypeError: String Index must be Integer](https://app.asana.com/0/346935762552316/537574721258972)

## Description - What does this PR do?
As mentioned in [elasticsearch-py - compatibility](http://elasticsearch-py.readthedocs.io/en/master/#compatibility) the library is compatible with all Elasticsearch versions since 0.90.x but we have to use a matching major version.

The costumer's (that got the error)  elasticsearch version is 6.0.1 and elasticsearch-py was 2.4.1 instead of 6.x.y.

I'v added multiple versions to support all Elasticsearch versions.