### PR TITLE
add certifi library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="panoply_elasticsearch",
-    version="1.0.5",
+    version="1.0.6",
     description="Panoply Data Source for Elasticsearch",
     author="Lior Rozen",
     author_email="lior@panoply.io",
@@ -11,7 +11,8 @@ setup(
         "panoply-python-sdk==1.3.2",
         "elasticsearch2",
         "elasticsearch5",
-        "elasticsearch>=6.0.0,<7.0.0"
+        "elasticsearch>=6.0.0,<7.0.0",
+        "certifi==2017.4.17"
     ],
 
     # place this package within the panoply package namespace


### PR DESCRIPTION

[Asana Task - Elasticserach -  root certificates are missing for certificate validation](https://app.asana.com/0/327352447154397/549360740827137)

According to https://elasticsearch-py.readthedocs.io/en/master/:
elasticsearch-py doesn’t ship with default set of root certificates. To have working SSL certificate validation you need to either specify your own as cafile or capath or cadata or install certifi which will be picked up automatically.

